### PR TITLE
Update auth.routes /logout route

### DIFF
--- a/basicAuth/routes/auth.routes.js
+++ b/basicAuth/routes/auth.routes.js
@@ -105,12 +105,14 @@ router.post('/login', (req, res, next) => {
 ///////////////////////////// LOGOUT ////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////
 
-router.post('/logout', (req, res) => {
-  req.session.destroy();
-  res.redirect('/');
+router.post('/logout', (req, res, next) => {
+  req.session.destroy((err) => {
+    if (err) next(err);
+    res.redirect('/');
+  })
 });
-// router.get('/userProfile', (req, res) => res.render('users/user-profile'));
 
+// router.get('/userProfile', (req, res) => res.render('users/user-profile'));
 router.get('/userProfile', (req, res) => {
   // console.log('your sess exp: ', req.session.cookie.expires);
   res.render('users/user-profile', { userInSession: req.session.currentUser });


### PR DESCRIPTION
As per the express-sessions docs, we should move to using `req.session.destroy()` method with a callback signature.

[reference](https://github.com/expressjs/session\#sessiondestroycallback)